### PR TITLE
Events

### DIFF
--- a/create_db.py
+++ b/create_db.py
@@ -1,7 +1,6 @@
 from clickhouse import ClickHouse, RepoClickHouseClient
 import argparse
 from clickhub import load_config, load_types
-import types
 
 
 parser = argparse.ArgumentParser(
@@ -15,7 +14,7 @@ parser.add_argument("-d", "--debug", action="store_true", help="debug")
 args = parser.parse_args()
 
 config = load_config(args.config)
-types = load_types()
+type = load_types()
 
 clickhouse = ClickHouse(
     host=config["host"],
@@ -30,7 +29,7 @@ client = RepoClickHouseClient(clickhouse)
 client.query_row("CREATE DATABASE IF NOT EXISTS git")
 
 for i in range(3):
-    client.query_row(types[i].statement)
+    client.query_row(type[i].statement)
 
 client.query_row(
     f"""

--- a/events_streaming.py
+++ b/events_streaming.py
@@ -27,14 +27,20 @@ clickhouse = ClickHouse(
 client = RepoClickHouseClient(clickhouse)
 
 
-
 if __name__ == "__main__":
     repo_names = client.query_rows("SELECT DISTINCT repo_name FROM git.commits")
     repos = [repo[0].split("/") for repo in repo_names]
-    #print(repos)
+    # print(repos)
 
     for owner, repo in repos:
-        row_data = pull_data(owner, repo)
-        #print(row_data)
+        url = f"https://api.github.com/repos/{owner}/{repo}/events"
+        row_data, next_link, f = pull_data(url)
         data = parse_data(row_data)
-        push_data(client, "event_type", data)
+        #print(data)
+        #push_data(client, "event_type", data)
+
+        while f:
+            row_data, next_link, f = pull_data(next_link)
+            data = parse_data(row_data)
+            print(data)
+            #push_data()

--- a/events_streaming.py
+++ b/events_streaming.py
@@ -1,0 +1,40 @@
+from clickhouse import ClickHouse, RepoClickHouseClient
+import argparse
+from clickhub import load_config
+from repo.pull_repo import pull_data, push_data, parse_data
+
+
+parser = argparse.ArgumentParser(
+    description="github importer",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+
+parser.add_argument("-c", "--config", default="config.yml", help="config")
+parser.add_argument("-d", "--debug", action="store_true", help="debug")
+
+args = parser.parse_args()
+
+config = load_config(args.config)
+
+clickhouse = ClickHouse(
+    host=config["host"],
+    port=config["port"],
+    native_port=config["native_port"],
+    username=config["username"],
+    password=config["password"],
+    secure=config["secure"],
+)
+client = RepoClickHouseClient(clickhouse)
+
+
+
+if __name__ == "__main__":
+    repo_names = client.query_rows("SELECT DISTINCT repo_name FROM git.commits")
+    repos = [repo[0].split("/") for repo in repo_names]
+    #print(repos)
+
+    for owner, repo in repos:
+        row_data = pull_data(owner, repo)
+        #print(row_data)
+        data = parse_data(row_data)
+        push_data(client, "event_type", data)

--- a/repo/pull_repo.py
+++ b/repo/pull_repo.py
@@ -1,0 +1,31 @@
+import requests
+import json
+
+
+def pull_data(owner, repo):
+    url = f"https://api.github.com/repos/{owner}/{repo}/events"
+    data = requests.get(url, params="--i")
+    if data.status_code == 200:
+        return data.text
+
+def parse_data(data):
+    data_list = json.loads(data)
+    event_types = []
+
+    for data_dict in data_list:
+        event_types.append(data_dict["type"])
+
+    return event_types
+
+def collect_data():
+    pass
+
+def push_data(client, column, data):
+    client.insert_row("git.github_events", data, column)
+
+
+#result = pull_data("0Kee-Team", "WatchAD")
+#data = parse_data(result)
+
+#push_data("event_type", data)
+

--- a/repo/pull_repo.py
+++ b/repo/pull_repo.py
@@ -2,30 +2,58 @@ import requests
 import json
 
 
-def pull_data(owner, repo):
-    url = f"https://api.github.com/repos/{owner}/{repo}/events"
-    data = requests.get(url, params="--i")
-    if data.status_code == 200:
-        return data.text
+def parse_link(string):
+    data = string.split()
+    next_link = data[0][1:-2]
+    
+    if "last" in string:
+        return next_link, True
+    else:
+        return "", False
+
+def pull_data(url):
+    data = requests.get(url)
+
+    next_link = ""
+    f = False
+
+    if "Link" in data.headers.keys():
+        next_link, f = parse_link(data.headers["Link"])
+    
+    return data.text, next_link, f
+
+def get_value(data, path):
+    for p in path:
+        data = data[p]
+    return data
 
 def parse_data(data):
     data_list = json.loads(data)
-    event_types = []
 
-    for data_dict in data_list:
-        event_types.append(data_dict["type"])
+    structure = {"event_type":["type"],
+                 "actor_login":["actor", "login"]}
+    res_data = {}
 
-    return event_types
+    for column in structure.keys():
+        res_list = []
+        for element in data_list:
+            path = structure[column]
+            res = get_value(element, path)
+            res_list.append(res) 
+
+        res_data[column] = res_list
+
+    return res_data
 
 def collect_data():
     pass
 
+
 def push_data(client, column, data):
-    client.insert_row("git.github_events", data, column)
+    client.insert_row("git.github_events", column, data)
 
 
-#result = pull_data("0Kee-Team", "WatchAD")
-#data = parse_data(result)
+# result = pull_data("0Kee-Team", "WatchAD")
+# data = parse_data(result)
 
-#push_data("event_type", data)
-
+# push_data("event_type", data)


### PR DESCRIPTION
Done: 
GitHub paginates the results and returns a subset of the results and links to the next parts, that is why I add processing of all links. 
I made structure for easier parsing data.
I can fill 2 columns in git.github_events. (single insert requests)

ToDo:
Because of pagination the program performs a lot of requests and limits the rate. I am working on it now. 
Parse data to fill all columns.
Add collecting method in order not to perform single insert requests.